### PR TITLE
Added User-login backend, and setup admin

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,9 @@ from datetime import datetime
 import models
 from database import engine, SessionLocal
 from sqlalchemy.orm import Session
+from routers import auth
+from dotenv import load_dotenv
+load_dotenv()
 
 app = FastAPI()
 models.Base.metadata.create_all(bind=engine)
@@ -22,6 +25,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.include_router(auth.router)
 
 def get_db():
     db = SessionLocal()

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,0 +1,108 @@
+# routers/auth.py
+from typing import List
+from fastapi import APIRouter, Depends, HTTPException, status, Response, Request
+from sqlalchemy.orm import Session
+
+from database import SessionLocal
+from models import Users
+from schemas_user import UserCreate, UserLogin, UserOut
+from security import hash_password, verify_password, create_access_token
+from jose import jwt, JWTError
+from security import SECRET_KEY, ALGORITHM
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+COOKIE_NAME = "hustlehub_access_token"
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+def get_user_from_token(request: Request, db: Session) -> Users:
+    token = request.cookies.get(COOKIE_NAME)
+    if not token:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id: int = int(payload.get("sub"))
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+    user = db.query(Users).filter(Users.user_id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=401, detail="User not found")
+
+    return user
+
+def require_admin(user: Users):
+    if user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin privileges required")
+
+# — REGISTRATION —
+@router.post("/register", response_model=UserOut)
+def register(user_in: UserCreate, db: Session = Depends(get_db)):
+    existing = db.query(Users).filter(Users.email == user_in.email).first()
+    if existing:
+        raise HTTPException(400, "Email already registered")
+
+    existing_username = db.query(Users).filter(Users.username == user_in.username).first()
+    if existing_username:
+        raise HTTPException(400, "Username already taken")
+
+    # Only allow applicant or employer during self-service registration
+    selected_role = user_in.role or "applicant"
+    if selected_role not in {"applicant", "employer"}:
+        raise HTTPException(400, "Invalid role selection")
+
+    user = Users(
+        username=user_in.username,
+        email=user_in.email,
+        password_hash=hash_password(user_in.password),
+        role=selected_role,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    return user
+
+# — LOGIN —
+@router.post("/login", response_model=UserOut)
+def login(user_in: UserLogin, response: Response, db: Session = Depends(get_db)):
+    user = db.query(Users).filter(Users.email == user_in.email).first()
+    if not user or not verify_password(user_in.password, user.password_hash):
+        raise HTTPException(400, "Invalid email or password")
+
+    token = create_access_token({"sub": str(user.user_id)})
+
+    response.set_cookie(
+        key=COOKIE_NAME,
+        value=token,
+        httponly=True,
+        samesite="lax",
+        secure=False,  # True in production
+        max_age=60 * 60 * 24,
+    )
+
+    return user
+
+# — LOGOUT —
+@router.post("/logout")
+def logout(response: Response):
+    response.delete_cookie(COOKIE_NAME)
+    return {"detail": "Logged out"}
+
+# — ME (user profile) —
+@router.get("/me", response_model=UserOut)
+def me(request: Request, db: Session = Depends(get_db)):
+    return get_user_from_token(request, db)
+
+@router.get("/users", response_model=List[UserOut])
+def list_users(request: Request, db: Session = Depends(get_db)):
+    user = get_user_from_token(request, db)
+    require_admin(user)
+    return db.query(Users).order_by(Users.user_id).all()

--- a/backend/schemas_user.py
+++ b/backend/schemas_user.py
@@ -1,0 +1,22 @@
+# schemas_user.py
+from typing import Literal
+from pydantic import BaseModel, EmailStr
+
+class UserBase(BaseModel):
+    username: str
+    email: EmailStr
+
+class UserCreate(UserBase):
+    password: str
+    role: Literal["applicant", "employer"] = "applicant"
+
+class UserLogin(BaseModel):
+    email: EmailStr
+    password: str
+
+class UserOut(UserBase):
+    user_id: int
+    role: str
+
+    class Config:
+        from_attributes = True

--- a/backend/security.py
+++ b/backend/security.py
@@ -1,0 +1,29 @@
+# security.py
+import os
+from dotenv import load_dotenv
+from passlib.context import CryptContext
+from jose import jwt, JWTError
+from datetime import datetime, timedelta, timezone
+
+load_dotenv()
+
+pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
+
+SECRET_KEY = os.getenv("SECRET_KEY")
+if not SECRET_KEY:
+    raise ValueError("SECRET_KEY is not set, please set it in the .env file.")
+
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24  # 1 day
+
+def hash_password(password: str) -> str:
+    return pwd_context.hash(password)
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return pwd_context.verify(plain, hashed)
+
+def create_access_token(data: dict, expires_delta=None):
+    to_encode = data.copy()
+    expire = datetime.now(timezone.utc) + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)

--- a/backend/seed_dummy_users.py
+++ b/backend/seed_dummy_users.py
@@ -1,0 +1,117 @@
+"""
+One-time helper script to seed local development data.
+Creates: 1 admin, 2 employers (with employer profiles), 2 applicants.
+
+Run from repo root or backend folder:
+    cd backend && python seed_dummy_users.py
+"""
+from database import SessionLocal
+from models import Users, Employers
+from security import hash_password
+
+
+def get_or_create_user(db, *, username: str, email: str, password: str, role: str) -> Users:
+    user = db.query(Users).filter(Users.email == email).first()
+    if user:
+        print(f"User already exists: {email} (role={user.role})")
+        return user
+
+    user = Users(
+        username=username,
+        email=email,
+        password_hash=hash_password(password),
+        role=role,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    print(f"Created user: {email} (role={role})")
+    return user
+
+
+def get_or_create_employer_profile(db, *, user: Users, company_name: str, description: str = "") -> Employers:
+    employer = db.query(Employers).filter(Employers.user_id == user.user_id).first()
+    if employer:
+        print(f"Employer profile already exists for user_id={user.user_id}")
+        return employer
+
+    employer = Employers(
+        user_id=user.user_id,
+        company_name=company_name,
+        description=description,
+        website=None,
+        location=None,
+    )
+    db.add(employer)
+    db.commit()
+    db.refresh(employer)
+    print(f"Created employer profile for {company_name} (user_id={user.user_id})")
+    return employer
+
+
+def main():
+    db = SessionLocal()
+    try:
+        # Only create an admin if none exists
+        existing_admin = db.query(Users).filter(Users.role == "admin").first()
+        if existing_admin:
+            print(f"Admin already exists: {existing_admin.email} (user_id={existing_admin.user_id})")
+            admin = existing_admin
+        else:
+            admin = get_or_create_user(
+                db,
+                username="admin",
+                email="admin@example.com",
+                password="password123",
+                role="admin",
+            )
+
+        employer1 = get_or_create_user(
+            db,
+            username="acme_hr",
+            email="hr@acme.com",
+            password="password123",
+            role="employer",
+        )
+        get_or_create_employer_profile(
+            db,
+            user=employer1,
+            company_name="Acme Corp",
+            description="Acme Corp builds everything.",
+        )
+
+        employer2 = get_or_create_user(
+            db,
+            username="globex_hr",
+            email="hr@globex.com",
+            password="password123",
+            role="employer",
+        )
+        get_or_create_employer_profile(
+            db,
+            user=employer2,
+            company_name="Globex Inc",
+            description="Globex builds future tech.",
+        )
+
+        get_or_create_user(
+            db,
+            username="alice_applicant",
+            email="alice@applicants.com",
+            password="password123",
+            role="applicant",
+        )
+
+        get_or_create_user(
+            db,
+            username="bob_applicant",
+            email="bob@applicants.com",
+            password="password123",
+            role="applicant",
+        )
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add admin-only /auth/users listing (cookie/JWT auth + role check)
- add reusable token-to-user helper and admin guard
- expose role on user output and allow employer/applicant role selection on register
- add seed_dummy_users.py to create 1 admin, 2 employers (with profiles), 2 applicants

## Manual Test Plan (curl)
# start API (in another shell): uvicorn main:app --reload

# register employer (or applicant)
curl -X POST http://localhost:8000/auth/register \
  -H "Content-Type: application/json" \
  -d '{"username":"acme","email":"hr@acme.com","password":"password123","role":"employer"}'

# login (saves cookie)
curl -X POST http://localhost:8000/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"hr@acme.com","password":"password123"}' \
  -c cookies.txt

# check current user
curl http://localhost:8000/auth/me -b cookies.txt

# admin-only list users (requires admin cookie)
curl http://localhost:8000/auth/users -b cookies.txt

# logout
curl -X POST http://localhost:8000/auth/logout -b cookies.txt

## DB Seed
# from backend/
python seed_dummy_users.py
# creates 1 admin (admin@example.com / password123), 2 employers (+profiles), 2 applicants; skips if already present
